### PR TITLE
Add Swift Package Manager support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,25 @@
+// swift-tools-version: 5.5
+import PackageDescription
+
+let package = Package(
+    name: "HeartLoadingView",
+    platforms: [
+        .iOS(.v8)
+    ],
+    products: [
+        .library(
+            name: "HeartLoadingView",
+            targets: ["HeartLoadingView"]
+        )
+    ],
+    dependencies: [
+    ],
+    targets: [
+        .target(
+            name: "HeartLoadingView",
+            path: "HeartLoadingView",
+            sources: ["Classes"]
+        )
+    ],
+    swiftLanguageVersions: [.v5]
+)

--- a/README.md
+++ b/README.md
@@ -71,6 +71,18 @@ heartLoadingView.isAnimated = true
 
 ## Installation
 
+### Swift Package Manager
+
+To integrate using Swift Package Manager, add the following dependency in your Package.swift:
+
+```swift
+.package(url: "https://github.com/ShvetsDima/HeartLoadingView.git", from: "1.0.0")
+```
+
+Then add `HeartLoadingView` to your target's dependencies.
+
+### Manually
+
 You can integrate HeartLoadingView by manually copying the source files into your project.
 
 ## License


### PR DESCRIPTION
## Summary
- add Package.swift manifest for Swift Package Manager
- document SPM installation steps in the README

## Testing
- `swift package describe`
- `swift build` *(fails: no such module 'UIKit')*

------
https://chatgpt.com/codex/tasks/task_e_6899ea04c890832a8dd337a42f93b050